### PR TITLE
Sorry, little mistake

### DIFF
--- a/myth/CIModules/auth/helpers/password_helper.php
+++ b/myth/CIModules/auth/helpers/password_helper.php
@@ -49,7 +49,7 @@ if (! function_exists('isStrongPassword'))
         {
             if (isset(get_instance()->form_validation))
             {
-                get_instance()->form_validation->set_message('isStrongPassword', 'lang:auth.pass_not_strong');
+                get_instance()->form_validation->set_message('isStrongPassword', lang('auth.pass_not_strong'));
             }
             return false;
         }


### PR DESCRIPTION
It doesn't work to use "lang: xxxx" vs "lang ('xxxx')" in Password Helper.
From a model that works well.
