### PR TITLE
Use correct migration class method

### DIFF
--- a/myth/CIModules/database/controllers/Database.php
+++ b/myth/CIModules/database/controllers/Database.php
@@ -101,7 +101,7 @@ class Database extends \Myth\Controllers\CLIController
         unset($groups);
 
         // Get our stats on the migrations
-        $latest = $this->migration->get_latest($type);
+        $latest = $this->migration->latest($type);
         $latest = empty($latest) ? 0 : $latest;
 
         if (empty($latest)) {


### PR DESCRIPTION
I was getting a "No migration found" when trying to install sprint and traced the culprit down to this! The correct method according to CI userguide is latest(). Can be tricky I know ;)
