### PR TITLE
Function via remember

### DIFF
--- a/myth/Auth/LocalAuthentication.php
+++ b/myth/Auth/LocalAuthentication.php
@@ -304,7 +304,10 @@ class LocalAuthentication implements AuthenticateInterface {
 
         $this->ci->load->helper('cookie');
 
-        $token = get_cookie('remember');
+        if (! $token = get_cookie('remember'))
+        {
+            return false;
+        }
 
         // Attempt to match the token against our auth_tokens table.
         $query = $this->ci->db->where('hash', $this->ci->login_model->hashRememberToken($token))


### PR DESCRIPTION
Hello,
Do not query `auth_tokens` table, if there is no cookie `remember`
