### PR TITLE
Update CIDbModel.php

### DIFF
--- a/myth/Models/CIDbModel.php
+++ b/myth/Models/CIDbModel.php
@@ -627,10 +627,11 @@ class CIDbModel
             $data = $this->validate($data);
         }
 
-        $data = $this->trigger('before_update', ['id' => $id, 'method' =>'update', 'fields' => $data] );
-
         // Will be false if it didn't validate.
         if ($data !== FALSE) {
+            
+            $data = $this->trigger('before_update', ['id' => $id, 'method' =>'update', 'fields' => $data] );
+            
             $this->db->where($this->primary_key, $id);
             $this->db->set( $this->prep_data($data) );
             $result = $this->db->update($this->table_name);


### PR DESCRIPTION
If validation fails for $data, variable $data setted to FALSE value. Then tries at trigger before_update function array_merge with array() and FALSE value and got warning:

```
Message: array_merge(): Argument #2 is not an array
```
