### PR TITLE
Fix for HMVC form validation rules with callbacks.

### DIFF
--- a/myth/Models/CIDbModel.php
+++ b/myth/Models/CIDbModel.php
@@ -316,7 +316,10 @@ class CIDbModel
         else {
             $this->load->library('form_validation');
         }
-
+        
+        // Fix for HMVC form validation rules with callbacks.
+        $this->form_validation->CI =& $this;
+        
         log_message('debug', 'CIDbModel Class Initialized');
     }
 


### PR DESCRIPTION
Form validation rules with callbacks wasnt working in modules. Fix based on HMVC documentation.
