### PR TITLE
Fix for callbacks in validation rules for models located in modules

### DIFF
--- a/application/libraries/MY_Form_validation.php
+++ b/application/libraries/MY_Form_validation.php
@@ -38,11 +38,11 @@ if (! class_exists('MY_Form_validation'))
          *
          * @return bool Success or Failure
          */
-//    public function run($module = '', $group = '')
-//    {
-//        is_object($module) && $this->CI =& $module;
-//        return parent::run($group);
-//    }
+        public function run($module = '', $group = '')
+        {
+            is_object($module) && $this->CI =& $module;
+            return parent::run($group);
+        }
 
         //--------------------------------------------------------------------
 

--- a/myth/Models/CIDbModel.php
+++ b/myth/Models/CIDbModel.php
@@ -317,9 +317,6 @@ class CIDbModel
             $this->load->library('form_validation');
         }
         
-        // Fix for HMVC form validation rules with callbacks.
-        $this->form_validation->CI =& $this;
-        
         log_message('debug', 'CIDbModel Class Initialized');
     }
 
@@ -1444,13 +1441,13 @@ class CIDbModel
 
                 $this->form_validation->set_rules($this->validation_rules);
 
-                if ($this->form_validation->run() === TRUE) {
+                if ($this->form_validation->run($this) === TRUE) {
                     return $data;
                 } else {
                     return FALSE;
                 }
             } else {
-                if ($this->form_validation->run($this->validate) === TRUE) {
+                if ($this->form_validation->run($this, $this->validate) === TRUE) {
                     return $data;
                 } else {
                     return FALSE;


### PR DESCRIPTION
Ok i think now it works good for both, model autoloaded from BaseController `protected $model_file`  and normal by `$this->load->model()`.

But dont close yet, let other people check it.
