### PR TITLE
LocalAuthentication login strategy update

### DIFF
--- a/tests/unit/myth/Auth/APIAuthenticationTest.php
+++ b/tests/unit/myth/Auth/APIAuthenticationTest.php
@@ -93,6 +93,8 @@ class APIAuthenticationTests extends CodeIgniterTestCase {
 		$this->auth->user_model->shouldReceive('where')->once()->andReturn( $this->auth->user_model );
 		$this->auth->user_model->shouldReceive('first')->once()->andReturn( false );
 
+		$this->ci->login_model->shouldReceive('recordLoginAttempt');
+
 		$this->assertFalse( $this->auth->tryBasicAuthentication() );
 	}
 

--- a/tests/unit/myth/Auth/LocalAuthenticationTest.php
+++ b/tests/unit/myth/Auth/LocalAuthenticationTest.php
@@ -68,6 +68,8 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
             'email' => 'darth@theempire.com',
         ];
 
+        $this->ci->login_model->shouldReceive('recordLoginAttempt');
+
         $result = $this->auth->validate($data);
 
         $this->assertNull($result);
@@ -85,6 +87,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
         $this->auth->user_model->shouldReceive('where')->with(['email' => 'darth@theempire.com'])->andReturn( $this->auth->user_model );
         $this->auth->user_model->shouldReceive('as_array')->andReturn( $this->user_model );
         $this->auth->user_model->shouldReceive('first')->andReturn(false);
+        $this->ci->login_model->shouldReceive('recordLoginAttempt');
 
         $result = $this->auth->validate($data);
 
@@ -135,6 +138,9 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
             'email' => 'darth@theempire.com'
         );
 
+        $this->ci->login_model->shouldReceive('lastLoginAttemptTime');
+        $this->ci->login_model->shouldReceive('distributedBruteForceTime');
+        $this->ci->login_model->shouldReceive('countLoginAttempts');
 	    $this->ci->login_model->shouldReceive('recordLoginAttempt');
 
         $result = $this->auth->login($creds);
@@ -172,6 +178,9 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
         $this->auth->user_model->shouldReceive('as_array')->andReturn( $this->auth->user_model );
         $this->auth->user_model->shouldReceive('first')->andReturn( false );
 
+        $this->ci->login_model->shouldReceive('lastLoginAttemptTime');
+        $this->ci->login_model->shouldReceive('distributedBruteForceTime');
+        $this->ci->login_model->shouldReceive('countLoginAttempts');
 	    $this->ci->login_model->shouldReceive('recordLoginAttempt');
 
         $result = $this->auth->login($creds);
@@ -191,6 +200,10 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
         $this->auth->user_model->shouldReceive('where')->with(['email' => 'darth@theempire.com'])->andReturn( $this->auth->user_model );
         $this->auth->user_model->shouldReceive('as_array')->andReturn( $this->auth->user_model );
         $this->auth->user_model->shouldReceive('first')->andReturn( $this->final_user );
+
+        $this->ci->login_model->shouldReceive('lastLoginAttemptTime');
+        $this->ci->login_model->shouldReceive('distributedBruteForceTime');
+        $this->ci->login_model->shouldReceive('countLoginAttempts');
         $this->ci->login_model->shouldReceive('recordLoginAttempt');
 
         $result = $this->auth->login($creds);


### PR DESCRIPTION
Login strategy (`LocalAuthentication::login`) seems a little strange to me:
1. Throttling is checked only if user exists but we log all login attempts, so it isn't right. I changed this to check throttling right after `validate` method.
2. When user sent request with good email and wrong password, `recordLoginAttempt` method is called twice. Once in `validation` method and second time in `login` method. I moved all this calls to `validation` method.

In this pull request I fix those two "problems", because both are tied up together.
