### PR TITLE
Fix time between failed login attempts

### DIFF
--- a/myth/Auth/LocalAuthentication.php
+++ b/myth/Auth/LocalAuthentication.php
@@ -574,7 +574,7 @@ class LocalAuthentication implements AuthenticateInterface {
 
         $max_time = config_item('auth.max_throttle_time');
 
-        $add_time = pow(5, $attempts);
+        $add_time = 5 * pow(2, $attempts - 1);
 
         if ($add_time > $max_time)
         {

--- a/tests/unit/myth/Auth/LocalAuthenticationTest.php
+++ b/tests/unit/myth/Auth/LocalAuthenticationTest.php
@@ -367,7 +367,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
         $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($email)->once()->andReturn( time() );
         $this->ci->login_model->shouldReceive('countLoginAttempts')->with($email)->once()->andReturn(7);
 
-        $this->assertEquals(25, $this->auth->isThrottled($email));
+        $this->assertEquals(10, $this->auth->isThrottled($email));
     }
 
     //--------------------------------------------------------------------
@@ -386,7 +386,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
         $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($email)->once()->andReturn( time() );
         $this->ci->login_model->shouldReceive('countLoginAttempts')->with($email)->once()->andReturn(8);
 
-        $this->assertEquals(50, $this->auth->isThrottled($email));
+        $this->assertEquals(20, $this->auth->isThrottled($email));
     }
 
     //--------------------------------------------------------------------
@@ -405,7 +405,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
         $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($email)->once()->andReturn( time() );
         $this->ci->login_model->shouldReceive('countLoginAttempts')->with($email)->once()->andReturn(9);
 
-        $this->assertEquals(50, $this->auth->isThrottled($email));
+        $this->assertEquals(40, $this->auth->isThrottled($email));
     }
 
     //--------------------------------------------------------------------


### PR DESCRIPTION
Time between failed login attempts is 5, 25 and 50 seconds (with default `max_throttle_time = 50`). 
But documentation says it should be 5, 10, 20, 40 and 50 seconds.
