### PR TITLE
Digest API Authentication add login attempts

### DIFF
--- a/myth/Api/Auth/APIAuthentication.php
+++ b/myth/Api/Auth/APIAuthentication.php
@@ -184,6 +184,11 @@ class APIAuthentication extends LocalAuthentication {
 		if (!  $user)
 		{
 			$this->ci->output->set_header( sprintf('WWW-Authenticate: Digest realm="%s", nonce="%s", opaque="%s"', config_item('api.realm'), $nonce, $opaque) );
+			// If an email is used, log the attempt
+            if (config_item('api.auth_field') === 'email')
+            {
+                $this->ci->login_model->recordLoginAttempt($digest['username']);
+            }
 			return false;
 		}
 
@@ -202,6 +207,11 @@ class APIAuthentication extends LocalAuthentication {
 		if ($digest['response'] != $valid_response)
 		{
 			$this->ci->output->set_header( sprintf('WWW-Authenticate: Digest realm="%s", nonce="%s", opaque="%s"', config_item('api.realm'), $nonce, $opaque) );
+			// If an email is used, log the attempt
+            if (config_item('api.auth_field') === 'email')
+            {
+                $this->ci->login_model->recordLoginAttempt($digest['username']);
+            }
 			return false;
 		}
 

--- a/tests/unit/myth/Auth/APIAuthenticationTest.php
+++ b/tests/unit/myth/Auth/APIAuthenticationTest.php
@@ -92,6 +92,7 @@ class APIAuthenticationTests extends CodeIgniterTestCase {
 		$this->auth->user_model->shouldReceive('as_array')->once()->andReturn( $this->auth->user_model );
 		$this->auth->user_model->shouldReceive('where')->once()->andReturn( $this->auth->user_model );
 		$this->auth->user_model->shouldReceive('first')->once()->andReturn( false );
+		$this->ci->login_model->shouldReceive('recordLoginAttempt');
 
 		$this->assertFalse( $this->auth->tryBasicAuthentication() );
 	}


### PR DESCRIPTION
Documentation says that failed login attempts on API are logged, but this is true only for Basic Authentication.
