### PR TITLE
#150 login attempts improvements

### DIFF
--- a/application/database/migrations/20160111121139_UpdateLoginAttemmptsTable.php
+++ b/application/database/migrations/20160111121139_UpdateLoginAttemmptsTable.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Migration: Update Login Attempts Table
+ *
+ * Created by: SprintPHP
+ * Created on: 2016-01-11 12:11pm
+ *
+ * @property $dbforge
+ */
+class Migration_UpdateLoginAttemmptsTable extends CI_Migration {
+
+    public function up()
+    {
+        $fields = array(
+            'type' => array(
+                'type'       => 'varchar',
+                'constraint' => 64,
+                'null'       => false,
+                'default'    => 'app',
+                'after'      => 'id'
+            ),
+            'ip_address' => array(
+                'type'       => 'varchar',
+                'constraint' => 255,
+                'null'       => true,
+                'after'      => 'type'
+            ),
+            'user_id' => array(
+                'type'       => 'int',
+                'constraint' => 11,
+                'unsigned'   => true,
+                'null'       => true,
+                'after'      => 'ip_address'
+            )
+        );
+
+        $this->dbforge->add_column('auth_login_attempts', $fields);
+
+        $this->db->query('ALTER TABLE `auth_login_attempts` ADD KEY (`user_id`)');
+
+        $this->dbforge->drop_column('auth_login_attempts', 'email');
+    }
+
+    //--------------------------------------------------------------------
+
+    public function down()
+    {
+        $this->dbforge->drop_column('auth_login_attempts', 'type');
+        $this->dbforge->drop_column('auth_login_attempts', 'ip_address');
+        $this->dbforge->drop_column('auth_login_attempts', 'user_id');
+
+        $column = ['email' => [
+            'type'       => 'varchar',
+            'constraint' => 255,
+            'after'      => 'id'
+        ]];
+
+        $this->dbforge->add_column('auth_login_attempts', $column);
+
+        $this->db->query('ALTER TABLE `auth_login_attempts` ADD KEY (`email`)');
+    }
+
+    //--------------------------------------------------------------------
+
+}

--- a/application/database/migrations/20160111121139_UpdateLoginAttemptsTable.php
+++ b/application/database/migrations/20160111121139_UpdateLoginAttemptsTable.php
@@ -8,7 +8,7 @@
  *
  * @property $dbforge
  */
-class Migration_UpdateLoginAttemmptsTable extends CI_Migration {
+class Migration_UpdateLoginAttemptsTable extends CI_Migration {
 
     public function up()
     {

--- a/myth/Api/Auth/APIAuthentication.php
+++ b/myth/Api/Auth/APIAuthentication.php
@@ -184,7 +184,7 @@ class APIAuthentication extends LocalAuthentication {
 		if (!  $user)
 		{
 			$this->ci->output->set_header( sprintf('WWW-Authenticate: Digest realm="%s", nonce="%s", opaque="%s"', config_item('api.realm'), $nonce, $opaque) );          
-            $this->ci->login_model->recordLoginAttempt($_SERVER['REMOTE_ADDR']);
+			$this->ci->login_model->recordLoginAttempt($this->ci->input->ip_address());
 			return false;
 		}
 
@@ -203,7 +203,7 @@ class APIAuthentication extends LocalAuthentication {
 		if ($digest['response'] != $valid_response)
 		{
 			$this->ci->output->set_header( sprintf('WWW-Authenticate: Digest realm="%s", nonce="%s", opaque="%s"', config_item('api.realm'), $nonce, $opaque) );
-			$this->ci->login_model->recordLoginAttempt($_SERVER['REMOTE_ADDR'], $user['id']);
+			$this->ci->login_model->recordLoginAttempt($this->ci->input->ip_address(), $user['id']);
 			return false;
 		}
 

--- a/myth/Auth/LocalAuthentication.php
+++ b/myth/Auth/LocalAuthentication.php
@@ -121,7 +121,7 @@ class LocalAuthentication implements AuthenticateInterface {
 
         if (! $user)
         {
-        	if (empty($this->error))
+            if (empty($this->error))
             {
                 // We need to set an error if there is no one
                 $this->error = lang('auth.invalid_user');
@@ -157,7 +157,7 @@ class LocalAuthentication implements AuthenticateInterface {
     public function validate($credentials, $return_user=false)
     {
         // Get ip address
-        $ip_address = $this->ci->input->server('REMOTE_ADDR');
+        $ip_address = $this->ci->input->ip_address();
 
         // We do not want to force case-sensitivity on things
         // like username and email for usability sake.
@@ -169,7 +169,7 @@ class LocalAuthentication implements AuthenticateInterface {
         // Can't validate without a password.
         if (empty($credentials['password']) || count($credentials) < 2)
         {
-        	$this->ci->login_model->recordLoginAttempt($ip_address);
+            $this->ci->login_model->recordLoginAttempt($ip_address);
             return null;
         }
 
@@ -511,7 +511,7 @@ class LocalAuthentication implements AuthenticateInterface {
         $user_id = $user ? $user['id'] : null;
         
         // Get ip address
-        $ip_address = $this->ci->input->server('REMOTE_ADDR');
+        $ip_address = $this->ci->input->ip_address();
 
         // Have any attempts been made?
         $attempts = $this->ci->login_model->countLoginAttempts($ip_address, $user_id);
@@ -903,7 +903,7 @@ class LocalAuthentication implements AuthenticateInterface {
         $this->user = $user;
 
         // Get ip address
-        $ip_address = $this->ci->input->server('REMOTE_ADDR');
+        $ip_address = $this->ci->input->ip_address();
 
         // Regenerate the session ID to help protect
         // against session fixation

--- a/myth/Auth/LocalAuthentication.php
+++ b/myth/Auth/LocalAuthentication.php
@@ -110,19 +110,13 @@ class LocalAuthentication implements AuthenticateInterface {
         // We need to test for this after validation because we
         // don't want it to affect a valid login.
 
-        // If there is user or email field available
-        if ($user || ! empty($credentials['email']))
+        // If throttling time is above zero, we can't allow
+        // logins now.
+        $time = (int)$this->isThrottled($user);
+        if ($time > 0)
         {
-        	// Set email to check
-            $email = $user ? $user['email'] : $credentials['email'];
-            // If throttling time is above zero, we can't allow
-        	// logins now.
-            $time = (int)$this->isThrottled($email);
-            if ($time > 0)
-            {
-                $this->error = sprintf(lang('auth.throttled'), $time);
-                return false;
-            }
+            $this->error = sprintf(lang('auth.throttled'), $time);
+            return false;
         }
 
         if (! $user)
@@ -162,6 +156,9 @@ class LocalAuthentication implements AuthenticateInterface {
      */
     public function validate($credentials, $return_user=false)
     {
+        // Get ip address
+        $ip_address = $this->ci->input->server('REMOTE_ADDR');
+
         // We do not want to force case-sensitivity on things
         // like username and email for usability sake.
         if (! empty($credentials['email']))
@@ -172,11 +169,7 @@ class LocalAuthentication implements AuthenticateInterface {
         // Can't validate without a password.
         if (empty($credentials['password']) || count($credentials) < 2)
         {
-        	// If an email is present, log the attempt
-            if (! empty($credentials['email']))
-            {
-                $this->ci->login_model->recordLoginAttempt($credentials['email']);
-            }
+        	$this->ci->login_model->recordLoginAttempt($ip_address);
             return null;
         }
 
@@ -188,11 +181,7 @@ class LocalAuthentication implements AuthenticateInterface {
         if (count($credentials) > 1)
         {
             $this->error = lang('auth.too_many_credentials');
-            // If an email is present, log the attempt
-            if (! empty($credentials['email']))
-            {
-                $this->ci->login_model->recordLoginAttempt($credentials['email']);
-            }
+            $this->ci->login_model->recordLoginAttempt($ip_address);
             return false;
         }
 
@@ -200,11 +189,7 @@ class LocalAuthentication implements AuthenticateInterface {
         if (! in_array(key($credentials), config_item('auth.valid_fields')) )
         {
             $this->error = lang('auth.invalid_credentials');
-            // If an email is present, log the attempt
-            if (! empty($credentials['email']))
-            {
-                $this->ci->login_model->recordLoginAttempt($credentials['email']);
-            }
+            $this->ci->login_model->recordLoginAttempt($ip_address);
             return false;
         }
 
@@ -216,11 +201,7 @@ class LocalAuthentication implements AuthenticateInterface {
         if (! $user)
         {
             $this->error = lang('auth.invalid_user');
-            // If an email is present, log the attempt
-            if (! empty($credentials['email']))
-            {
-                $this->ci->login_model->recordLoginAttempt($credentials['email']);
-            }
+            $this->ci->login_model->recordLoginAttempt($ip_address);
             return false;
         }
 
@@ -230,7 +211,7 @@ class LocalAuthentication implements AuthenticateInterface {
         if (! $result)
         {
             $this->error = lang('auth.invalid_password');
-            $this->ci->login_model->recordLoginAttempt($user['email']);
+            $this->ci->login_model->recordLoginAttempt($ip_address, $user['id']);
             return false;
         }
 
@@ -518,7 +499,7 @@ class LocalAuthentication implements AuthenticateInterface {
      * @param $email
      * @return mixed
      */
-    public function isThrottled($email)
+    public function isThrottled($user)
     {
         // Not throttling? Get outta here!
         if (! config_item('auth.allow_throttling'))
@@ -526,11 +507,14 @@ class LocalAuthentication implements AuthenticateInterface {
             return false;
         }
 
-        // Emails should NOT be case sensitive.
-        $email = strtolower($email);
+        // Get user_id
+        $user_id = $user ? $user['id'] : null;
+        
+        // Get ip address
+        $ip_address = $this->ci->input->server('REMOTE_ADDR');
 
         // Have any attempts been made?
-        $attempts = $this->ci->login_model->countLoginAttempts($email);
+        $attempts = $this->ci->login_model->countLoginAttempts($ip_address, $user_id);
 
         // Grab the amount of time to add if the system thinks we're
         // under a distributed brute force attack.
@@ -558,7 +542,7 @@ class LocalAuthentication implements AuthenticateInterface {
 
         // Grab the time of last attempt and
         // determine if we're throttled by amount of time passed.
-        $last_time = $this->ci->login_model->lastLoginAttemptTime($email);
+        $last_time = $this->ci->login_model->lastLoginAttemptTime($ip_address, $user_id);
 
         $allowed = config_item('auth.allowed_login_attempts');
 
@@ -582,7 +566,7 @@ class LocalAuthentication implements AuthenticateInterface {
         // to check the elapsed time of all of these attacks. If they are
         // less than 1 minute it's obvious this is a brute force attack,
         // so we'll set a session flag and block that user for 15 minutes.
-        if ($attempts > 100 && $this->ci->login_model->isBruteForced($email))
+        if ($attempts > 100 && $this->ci->login_model->isBruteForced($ip_address, $user_id))
         {
             $this->error = lang('auth.bruteBan_notice');
 
@@ -918,6 +902,9 @@ class LocalAuthentication implements AuthenticateInterface {
         // Save the user for later access
         $this->user = $user;
 
+        // Get ip address
+        $ip_address = $this->ci->input->server('REMOTE_ADDR');
+
         // Regenerate the session ID to help protect
         // against session fixation
         $this->ci->session->sess_regenerate();
@@ -926,7 +913,7 @@ class LocalAuthentication implements AuthenticateInterface {
         $this->ci->session->set_userdata('logged_in', $user['id']);
 
         // Clear our login attempts
-        $this->ci->login_model->purgeLoginAttempts($user['email']);
+        $this->ci->login_model->purgeLoginAttempts($ip_address, $user['id']);
 
         // Record a new Login
         $this->ci->login_model->recordLogin($user);

--- a/tests/unit/myth/Auth/APIAuthenticationTest.php
+++ b/tests/unit/myth/Auth/APIAuthenticationTest.php
@@ -92,7 +92,6 @@ class APIAuthenticationTests extends CodeIgniterTestCase {
 		$this->auth->user_model->shouldReceive('as_array')->once()->andReturn( $this->auth->user_model );
 		$this->auth->user_model->shouldReceive('where')->once()->andReturn( $this->auth->user_model );
 		$this->auth->user_model->shouldReceive('first')->once()->andReturn( false );
-		$this->ci->login_model->shouldReceive('recordLoginAttempt');
 
 		$this->ci->login_model->shouldReceive('recordLoginAttempt');
 

--- a/tests/unit/myth/Auth/LocalAuthenticationTest.php
+++ b/tests/unit/myth/Auth/LocalAuthenticationTest.php
@@ -114,21 +114,21 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
 
     //--------------------------------------------------------------------
 
-	public function testValidateReturnsFalseWithInvalidField()
-	{
-		$data = [
-			'display_name' => 'darth@theempire.com',
-			'password' => 'father'
-		];
+    public function testValidateReturnsFalseWithInvalidField()
+    {
+        $data = [
+            'display_name' => 'darth@theempire.com',
+            'password' => 'father'
+        ];
 
         $this->ci->login_model->shouldReceive('recordLoginAttempt');
 
-		$result = $this->auth->validate($data);
+        $result = $this->auth->validate($data);
 
-		$this->assertFalse($result);
-	}
+        $this->assertFalse($result);
+    }
 
-	//--------------------------------------------------------------------
+    //--------------------------------------------------------------------
 
     //--------------------------------------------------------------------
     // Login
@@ -143,7 +143,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
         $this->ci->login_model->shouldReceive('lastLoginAttemptTime');
         $this->ci->login_model->shouldReceive('distributedBruteForceTime');
         $this->ci->login_model->shouldReceive('countLoginAttempts');
-	    $this->ci->login_model->shouldReceive('recordLoginAttempt');
+        $this->ci->login_model->shouldReceive('recordLoginAttempt');
 
         $result = $this->auth->login($creds);
 
@@ -188,7 +188,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
         $this->ci->login_model->shouldReceive('lastLoginAttemptTime');
         $this->ci->login_model->shouldReceive('distributedBruteForceTime');
         $this->ci->login_model->shouldReceive('countLoginAttempts');
-	    $this->ci->login_model->shouldReceive('recordLoginAttempt');
+        $this->ci->login_model->shouldReceive('recordLoginAttempt');
 
         $result = $this->auth->login($creds);
 
@@ -222,7 +222,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
 
     public function testLoginReturnsTrueWithGoodCreds()
     {
-        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+        $_SERVER['REMOTE_ADDR'] = '0.0.0.0';
 
         $creds = array(
             'email' => 'darth@theempire.com',
@@ -234,7 +234,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
         $this->auth->user_model->shouldReceive('first')->andReturn( $this->final_user );
         $this->ci->session->shouldReceive('set_userdata')->with('logged_in', true);
         $this->ci->session->shouldReceive('sess_regenerate');
-        $this->ci->login_model->shouldReceive('purgeLoginAttempts')->with('192.168.10.1', 15);
+        $this->ci->login_model->shouldReceive('purgeLoginAttempts')->with($_SERVER['REMOTE_ADDR'], 15);
         $this->ci->login_model->shouldReceive('recordLogin')->with($this->final_user);
         $this->ci->login_model->shouldReceive('purgeOldRememberTokens')->zeroOrMoreTimes();
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->andReturn(0);
@@ -250,7 +250,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
 
     public function testLoginSetsUserObjectAndUserGrabsIt()
     {
-        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+        $_SERVER['REMOTE_ADDR'] = '0.0.0.0';
 
         $creds = array(
             'email' => 'darth@theempire.com',
@@ -262,7 +262,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
         $this->auth->user_model->shouldReceive('first')->andReturn( $this->final_user );
         $this->ci->session->shouldReceive('set_userdata')->with('logged_in', true);
         $this->ci->session->shouldReceive('sess_regenerate');
-        $this->ci->login_model->shouldReceive('purgeLoginAttempts')->with('192.168.10.1', 15);
+        $this->ci->login_model->shouldReceive('purgeLoginAttempts')->with($_SERVER['REMOTE_ADDR'], 15);
         $this->ci->login_model->shouldReceive('recordLogin')->with($this->final_user);
         $this->ci->login_model->shouldReceive('purgeOldRememberTokens')->zeroOrMoreTimes();
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->andReturn(0);
@@ -278,7 +278,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
 
     public function testIdReturnsCorrectlyWithValidLogin()
     {
-        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+        $_SERVER['REMOTE_ADDR'] = '0.0.0.0';
 
         $creds = array(
             'email' => 'darth@theempire.com',
@@ -290,7 +290,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
         $this->auth->user_model->shouldReceive('first')->andReturn( $this->final_user );
         $this->ci->session->shouldReceive('set_userdata')->with('logged_in', true);
         $this->ci->session->shouldReceive('sess_regenerate');
-        $this->ci->login_model->shouldReceive('purgeLoginAttempts')->with('192.168.10.1', 15);
+        $this->ci->login_model->shouldReceive('purgeLoginAttempts')->with($_SERVER['REMOTE_ADDR'], 15);
         $this->ci->login_model->shouldReceive('recordLogin')->with($this->final_user);
         $this->ci->login_model->shouldReceive('purgeOldRememberTokens')->zeroOrMoreTimes();
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->andReturn(0);
@@ -328,7 +328,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
     public function testThrottlingReturnsFalseIfNotThrottledWithFirstFailedAttempt()
     {
         $user = ['id' => 15];
-        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+        $_SERVER['REMOTE_ADDR'] = '0.0.0.0';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(0);
@@ -348,7 +348,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
     public function testThrottlingReturnsFalseIfNotThrottledWithAllowedFailedAttempts()
     {
         $user = ['id' => 15];
-        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+        $_SERVER['REMOTE_ADDR'] = '0.0.0.0';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(0);
@@ -368,7 +368,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
     public function testThrottlingReturnsTimeWhenThrottled()
     {
         $user = ['id' => 15];
-        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+        $_SERVER['REMOTE_ADDR'] = '0.0.0.0';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(0);
@@ -388,7 +388,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
     public function testThrottlingReturnsTimeWhenThrottled2()
     {
         $user = ['id' => 15];
-        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+        $_SERVER['REMOTE_ADDR'] = '0.0.0.0';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(0);
@@ -408,7 +408,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
     public function testThrottlingReturnsTimeWhenThrottled3()
     {
         $user = ['id' => 15];
-        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+        $_SERVER['REMOTE_ADDR'] = '0.0.0.0';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(0);
@@ -428,7 +428,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
     public function testThrottlingReturnsTimeWhenThrottled4()
     {
         $user = ['id' => 15];
-        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+        $_SERVER['REMOTE_ADDR'] = '0.0.0.0';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(0);
@@ -448,7 +448,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
     public function testThrottlingReturnsTimeWhenThrottled5()
     {
         $user = ['id' => 15];
-        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+        $_SERVER['REMOTE_ADDR'] = '0.0.0.0';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(0);
@@ -468,7 +468,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
     public function testThrottlingReturnsTimeWhenThrottled6AndIsAboveMaxLimit()
     {
         $user = ['id' => 15];
-        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+        $_SERVER['REMOTE_ADDR'] = '0.0.0.0';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(0);
@@ -488,7 +488,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
     public function testThrottlingUnderBruteForceFirstTime()
     {
         $user = ['id' => 15];
-        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+        $_SERVER['REMOTE_ADDR'] = '0.0.0.0';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(0);
@@ -512,7 +512,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
     public function testThrottlingUnderPreviousBruteForce()
     {
         $user = ['id' => 15];
-        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+        $_SERVER['REMOTE_ADDR'] = '0.0.0.0';
 
         $bruteTime = (60*14) + time();
         $_SESSION['bruteBan'] = $bruteTime;
@@ -540,7 +540,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
     public function testThrottlingUnderPreviousBruteForceWithDBrute()
     {
         $user = ['id' => 15];
-        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+        $_SERVER['REMOTE_ADDR'] = '0.0.0.0';
 
         $bruteTime = (60*14) + time();
         $_SESSION['bruteBan'] = $bruteTime;
@@ -568,7 +568,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
     public function testThrottlingWithAllowedAttemptsUnderDBrute()
     {
         $user = ['id' => 15];
-        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+        $_SERVER['REMOTE_ADDR'] = '0.0.0.0';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(45);
@@ -587,7 +587,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
      */
     public function testThrottlingThroughLoginMethod()
     {
-        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+        $_SERVER['REMOTE_ADDR'] = '0.0.0.0';
         $user_id = 54;
 
         $creds = [

--- a/tests/unit/myth/Auth/LocalAuthenticationTest.php
+++ b/tests/unit/myth/Auth/LocalAuthenticationTest.php
@@ -121,6 +121,8 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
 			'password' => 'father'
 		];
 
+        $this->ci->login_model->shouldReceive('recordLoginAttempt');
+
 		$result = $this->auth->validate($data);
 
 		$this->assertFalse($result);
@@ -159,6 +161,11 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
         $this->auth->user_model->shouldReceive('select')->andReturn( $this->auth->user_model );
         $this->auth->user_model->shouldReceive('where')->andReturn( $this->auth->user_model );
         $this->auth->user_model->shouldReceive('first')->andReturn( null );
+
+        $this->ci->login_model->shouldReceive('lastLoginAttemptTime');
+        $this->ci->login_model->shouldReceive('distributedBruteForceTime');
+        $this->ci->login_model->shouldReceive('countLoginAttempts');
+        $this->ci->login_model->shouldReceive('recordLoginAttempt');
 
         $result = $this->auth->login($creds);
 
@@ -215,6 +222,8 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
 
     public function testLoginReturnsTrueWithGoodCreds()
     {
+        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+
         $creds = array(
             'email' => 'darth@theempire.com',
             'password' => 'father'
@@ -225,7 +234,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
         $this->auth->user_model->shouldReceive('first')->andReturn( $this->final_user );
         $this->ci->session->shouldReceive('set_userdata')->with('logged_in', true);
         $this->ci->session->shouldReceive('sess_regenerate');
-        $this->ci->login_model->shouldReceive('purgeLoginAttempts')->with('darth@theempire.com');
+        $this->ci->login_model->shouldReceive('purgeLoginAttempts')->with('192.168.10.1', 15);
         $this->ci->login_model->shouldReceive('recordLogin')->with($this->final_user);
         $this->ci->login_model->shouldReceive('purgeOldRememberTokens')->zeroOrMoreTimes();
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->andReturn(0);
@@ -241,6 +250,8 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
 
     public function testLoginSetsUserObjectAndUserGrabsIt()
     {
+        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+
         $creds = array(
             'email' => 'darth@theempire.com',
             'password' => 'father'
@@ -251,7 +262,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
         $this->auth->user_model->shouldReceive('first')->andReturn( $this->final_user );
         $this->ci->session->shouldReceive('set_userdata')->with('logged_in', true);
         $this->ci->session->shouldReceive('sess_regenerate');
-        $this->ci->login_model->shouldReceive('purgeLoginAttempts')->with('darth@theempire.com');
+        $this->ci->login_model->shouldReceive('purgeLoginAttempts')->with('192.168.10.1', 15);
         $this->ci->login_model->shouldReceive('recordLogin')->with($this->final_user);
         $this->ci->login_model->shouldReceive('purgeOldRememberTokens')->zeroOrMoreTimes();
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->andReturn(0);
@@ -267,6 +278,8 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
 
     public function testIdReturnsCorrectlyWithValidLogin()
     {
+        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+
         $creds = array(
             'email' => 'darth@theempire.com',
             'password' => 'father'
@@ -277,7 +290,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
         $this->auth->user_model->shouldReceive('first')->andReturn( $this->final_user );
         $this->ci->session->shouldReceive('set_userdata')->with('logged_in', true);
         $this->ci->session->shouldReceive('sess_regenerate');
-        $this->ci->login_model->shouldReceive('purgeLoginAttempts')->with('darth@theempire.com');
+        $this->ci->login_model->shouldReceive('purgeLoginAttempts')->with('192.168.10.1', 15);
         $this->ci->login_model->shouldReceive('recordLogin')->with($this->final_user);
         $this->ci->login_model->shouldReceive('purgeOldRememberTokens')->zeroOrMoreTimes();
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->andReturn(0);
@@ -314,16 +327,17 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
      */
     public function testThrottlingReturnsFalseIfNotThrottledWithFirstFailedAttempt()
     {
-        $email = 'darth@theempire.com';
+        $user = ['id' => 15];
+        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(0);
         // Not under a brute force attack
         $this->ci->session->shouldReceive('userdata')->with('bruteBan')->once()->andReturn(false);
-        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($email)->once()->andReturn(0);
-        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($email)->once()->andReturn(0);
+        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn(0);
+        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn(0);
 
-        $this->assertFalse($this->auth->isThrottled($email));
+        $this->assertFalse($this->auth->isThrottled($user));
     }
 
     //--------------------------------------------------------------------
@@ -333,16 +347,17 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
      */
     public function testThrottlingReturnsFalseIfNotThrottledWithAllowedFailedAttempts()
     {
-        $email = 'darth@theempire.com';
+        $user = ['id' => 15];
+        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(0);
         // Not under a brute force attack
         $this->ci->session->shouldReceive('userdata')->with('bruteBan')->once()->andReturn(false);
-        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($email)->once()->andReturn(0);
-        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($email)->once()->andReturn(3);
+        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn(0);
+        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn(3);
 
-        $this->assertFalse($this->auth->isThrottled($email));
+        $this->assertFalse($this->auth->isThrottled($user));
     }
 
     //--------------------------------------------------------------------
@@ -352,16 +367,17 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
      */
     public function testThrottlingReturnsTimeWhenThrottled()
     {
-        $email = 'darth@theempire.com';
+        $user = ['id' => 15];
+        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(0);
         // Not under a brute force attack
         $this->ci->session->shouldReceive('userdata')->with('bruteBan')->once()->andReturn(false);
-        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($email)->once()->andReturn( time() );
-        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($email)->once()->andReturn(6);
+        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn( time() );
+        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn(6);
 
-        $this->assertEquals(5, $this->auth->isThrottled($email));
+        $this->assertEquals(5, $this->auth->isThrottled($user));
     }
 
     //--------------------------------------------------------------------
@@ -371,16 +387,17 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
      */
     public function testThrottlingReturnsTimeWhenThrottled2()
     {
-        $email = 'darth@theempire.com';
+        $user = ['id' => 15];
+        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(0);
         // Not under a brute force attack
         $this->ci->session->shouldReceive('userdata')->with('bruteBan')->once()->andReturn(false);
-        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($email)->once()->andReturn( time() );
-        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($email)->once()->andReturn(7);
+        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn( time() );
+        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn(7);
 
-        $this->assertEquals(10, $this->auth->isThrottled($email));
+        $this->assertEquals(10, $this->auth->isThrottled($user));
     }
 
     //--------------------------------------------------------------------
@@ -390,16 +407,17 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
      */
     public function testThrottlingReturnsTimeWhenThrottled3()
     {
-        $email = 'darth@theempire.com';
+        $user = ['id' => 15];
+        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(0);
         // Not under a brute force attack
         $this->ci->session->shouldReceive('userdata')->with('bruteBan')->once()->andReturn(false);
-        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($email)->once()->andReturn( time() );
-        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($email)->once()->andReturn(8);
+        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn( time() );
+        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn(8);
 
-        $this->assertEquals(20, $this->auth->isThrottled($email));
+        $this->assertEquals(20, $this->auth->isThrottled($user));
     }
 
     //--------------------------------------------------------------------
@@ -409,16 +427,17 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
      */
     public function testThrottlingReturnsTimeWhenThrottled4()
     {
-        $email = 'darth@theempire.com';
+        $user = ['id' => 15];
+        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(0);
         // Not under a brute force attack
         $this->ci->session->shouldReceive('userdata')->with('bruteBan')->once()->andReturn(false);
-        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($email)->once()->andReturn( time() );
-        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($email)->once()->andReturn(9);
+        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn( time() );
+        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn(9);
 
-        $this->assertEquals(40, $this->auth->isThrottled($email));
+        $this->assertEquals(40, $this->auth->isThrottled($user));
     }
 
     //--------------------------------------------------------------------
@@ -428,16 +447,17 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
      */
     public function testThrottlingReturnsTimeWhenThrottled5()
     {
-        $email = 'darth@theempire.com';
+        $user = ['id' => 15];
+        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(0);
         // Not under a brute force attack
         $this->ci->session->shouldReceive('userdata')->with('bruteBan')->once()->andReturn(false);
-        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($email)->once()->andReturn( time() );
-        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($email)->once()->andReturn(10);
+        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn( time() );
+        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn(10);
 
-        $this->assertEquals(50, $this->auth->isThrottled($email));
+        $this->assertEquals(50, $this->auth->isThrottled($user));
     }
 
     //--------------------------------------------------------------------
@@ -447,16 +467,17 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
      */
     public function testThrottlingReturnsTimeWhenThrottled6AndIsAboveMaxLimit()
     {
-        $email = 'darth@theempire.com';
+        $user = ['id' => 15];
+        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(0);
         // Not under a brute force attack
         $this->ci->session->shouldReceive('userdata')->with('bruteBan')->once()->andReturn(false);
-        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($email)->once()->andReturn( time() );
-        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($email)->once()->andReturn(11);
+        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn( time() );
+        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn(11);
 
-        $this->assertEquals(50, $this->auth->isThrottled($email));
+        $this->assertEquals(50, $this->auth->isThrottled($user));
     }
 
     //--------------------------------------------------------------------
@@ -466,20 +487,21 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
      */
     public function testThrottlingUnderBruteForceFirstTime()
     {
-        $email = 'darth@theempire.com';
+        $user = ['id' => 15];
+        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(0);
         // Not under a brute force attack
         $this->ci->session->shouldReceive('userdata')->with('bruteBan')->once()->andReturn(false);
-        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($email)->once()->andReturn( time() );
-        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($email)->once()->andReturn(101);
-        $this->ci->login_model->shouldReceive('isBruteForced')->with($email)->once()->andReturn(true);
+        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn( time() );
+        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn(101);
+        $this->ci->login_model->shouldReceive('isBruteForced')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn(true);
 
         // Should store current time+15 minutes in the session
         $this->ci->session->shouldReceive('set_userdata')->with('bruteBan', time() + (60*15))->once();
 
-        $this->assertEquals(60*15, $this->auth->isThrottled($email));
+        $this->assertEquals(60*15, $this->auth->isThrottled($user));
     }
 
     //--------------------------------------------------------------------
@@ -489,7 +511,8 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
      */
     public function testThrottlingUnderPreviousBruteForce()
     {
-        $email = 'darth@theempire.com';
+        $user = ['id' => 15];
+        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
 
         $bruteTime = (60*14) + time();
         $_SESSION['bruteBan'] = $bruteTime;
@@ -498,14 +521,14 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(0);
         // Not under a brute force attack
 //        $this->ci->session->shouldReceive('userdata')->with('bruteBan')->once()->andReturn( $bruteTime );
-        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($email)->never();
-        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($email)->never();
-        $this->ci->login_model->shouldReceive('isBruteForced')->with($email)->never();
+        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($_SERVER['REMOTE_ADDR'], $user['id'])->never();
+        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($_SERVER['REMOTE_ADDR'], $user['id'])->never();
+        $this->ci->login_model->shouldReceive('isBruteForced')->with($_SERVER['REMOTE_ADDR'], $user['id'])->never();
 
         // Should store current time+15 minutes in the session
         $this->ci->session->shouldReceive('set_userdata')->with('bruteBan', time() + (60*15))->never();
 
-        $this->assertEquals($bruteTime - time(), $this->auth->isThrottled($email));
+        $this->assertEquals($bruteTime - time(), $this->auth->isThrottled($user));
         unset($_SESSION['bruteBan']);
     }
 
@@ -516,7 +539,8 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
      */
     public function testThrottlingUnderPreviousBruteForceWithDBrute()
     {
-        $email = 'darth@theempire.com';
+        $user = ['id' => 15];
+        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
 
         $bruteTime = (60*14) + time();
         $_SESSION['bruteBan'] = $bruteTime;
@@ -525,14 +549,14 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(45);
         // Not under a brute force attack
 //        $this->ci->session->shouldReceive('userdata')->with('bruteBan')->once()->andReturn( $bruteTime );
-        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($email)->never();
-        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($email)->never();
-        $this->ci->login_model->shouldReceive('isBruteForced')->with($email)->never();
+        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($_SERVER['REMOTE_ADDR'], $user['id'])->never();
+        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($_SERVER['REMOTE_ADDR'], $user['id'])->never();
+        $this->ci->login_model->shouldReceive('isBruteForced')->with($_SERVER['REMOTE_ADDR'], $user['id'])->never();
 
         // Should store current time+15 minutes in the session
         $this->ci->session->shouldReceive('set_userdata')->with('bruteBan', time() + (60*15))->never();
 
-        $this->assertEquals($bruteTime - time() + 45, $this->auth->isThrottled($email));
+        $this->assertEquals($bruteTime - time() + 45, $this->auth->isThrottled($user));
         unset($_SESSION['bruteBan']);
     }
 
@@ -543,16 +567,17 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
      */
     public function testThrottlingWithAllowedAttemptsUnderDBrute()
     {
-        $email = 'darth@theempire.com';
+        $user = ['id' => 15];
+        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
 
         // Not under a distributed brute force attack.
         $this->ci->login_model->shouldReceive('distributedBruteForceTime')->once()->andReturn(45);
         // Not under a brute force attack
         $this->ci->session->shouldReceive('userdata')->with('bruteBan')->once()->andReturn(false);
-        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($email)->once()->andReturn( strtotime('-10 seconds') );
-        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($email)->once()->andReturn(3);
+        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn( strtotime('-10 seconds') );
+        $this->ci->login_model->shouldReceive('countLoginAttempts')->with($_SERVER['REMOTE_ADDR'], $user['id'])->once()->andReturn(3);
 
-        $this->assertEquals(35, $this->auth->isThrottled($email));
+        $this->assertEquals(35, $this->auth->isThrottled($user));
     }
 
     //--------------------------------------------------------------------
@@ -562,6 +587,9 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
      */
     public function testThrottlingThroughLoginMethod()
     {
+        $_SERVER['REMOTE_ADDR'] = '192.168.10.1';
+        $user_id = 54;
+
         $creds = [
             'email' => 'darth@theempire.com',
             'password' => 'iwantthethrone'
@@ -584,7 +612,7 @@ class LocalAuthenticationTest extends CodeIgniterTestCase {
 
         // Are under a brute force attack
         $this->ci->session->shouldReceive('userdata')->with('bruteBan')->once()->andReturn(45);
-        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($creds['email'])->once()->andReturn( strtotime('-10 seconds') );
+        $this->ci->login_model->shouldReceive('lastLoginAttemptTime')->with($_SERVER['REMOTE_ADDR'], $user_id)->once()->andReturn( strtotime('-10 seconds') );
         $this->ci->login_model->shouldReceive('countLoginAttempts')->andReturn(113);
 
         $this->ci->login_model->shouldReceive('isBruteForced')->andReturn(true);


### PR DESCRIPTION
Basically, this pull request introduce types for login attempts:
- `app` - log all failed attempts
- `ip` - log all failed attempts by IP address
- `user` - log all failed attempts by user ID

Entries for `app` type are never deleted, so we have always full log history to use with `distributedBruteForceTime` method. We are able to set ban for users based on IP address or user ID - rules are the same as before. And last but not least we're independent from field used during login.
