### PR TITLE
Fix purgeLoginAttempts method

### DIFF
--- a/myth/Auth/AuthenticateInterface.php
+++ b/myth/Auth/AuthenticateInterface.php
@@ -217,9 +217,10 @@ interface AuthenticateInterface {
     /**
      * Purges all login attempt records from the database.
      *
-     * @param $email
+     * @param null $ip_address
+     * @param null $user_id
      */
-    public function purgeLoginAttempts($email);
+    public function purgeLoginAttempts($ip_address = null, $user_id = null);
 
     //--------------------------------------------------------------------
 

--- a/myth/Auth/LocalAuthentication.php
+++ b/myth/Auth/LocalAuthentication.php
@@ -786,14 +786,12 @@ class LocalAuthentication implements AuthenticateInterface {
     /**
      * Purges all login attempt records from the database.
      *
-     * @param $email
+     * @param null $ip_address
+     * @param null $user_id
      */
-    public function purgeLoginAttempts($email)
+    public function purgeLoginAttempts($ip_address = null, $user_id = null)
     {
-        // Emails should NOT be case sensitive.
-        $email = strtolower($email);
-
-        $this->ci->login_model->purgeLoginAttempts($email);
+        $this->ci->login_model->purgeLoginAttempts($ip_address, $user_id);
 
         // @todo record activity of login attempts purge.
         Events::trigger('didPurgeLoginAttempts', [$email]);

--- a/myth/CIModules/auth/models/Login_model.php
+++ b/myth/CIModules/auth/models/Login_model.php
@@ -108,9 +108,17 @@ class Login_model extends \Myth\Models\CIDbModel {
      */
     public function purgeLoginAttempts($ip_address, $user_id)
     {
-        return $this->db->where('ip_address', $ip_address)
-                        ->or_where('user_id', $user_id)
-                        ->delete('auth_login_attempts');
+        if ($ip_address)
+        {
+            $this->db->where('ip_address', $ip_address);
+        }
+
+        if ($user_id)
+        {
+            $this->db->or_where('user_id', $user_id);
+        }
+
+        return $this->db->delete('auth_login_attempts');
     }
 
     //--------------------------------------------------------------------


### PR DESCRIPTION
In one of my previous pull request (#151), I made changes to `Login_model::purgeLoginAttempts` method but forgot about `LocalAuhentication::purgeLoginAttempts` since we don't use this method internally.

Now it's fixed.
