### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
 	},
     "require-dev": {
         "mockery/mockery": "dev-master",
+        "hamcrest/hamcrest-php": "dev-master",
         "fzaninotto/faker": "1.5.*@dev"
     },
     "scripts": {


### PR DESCRIPTION
Calling `composer update`, returns error that:
`mockery/mockery dev-master requires hamcrest/hamcrest-php ^2.0@dev`
