### PR TITLE
Update Databse.php to errors on Refresh

### DIFF
--- a/myth/CIModules/database/controllers/Database.php
+++ b/myth/CIModules/database/controllers/Database.php
@@ -171,6 +171,9 @@ class Database extends \Myth\Controllers\CLIController
     public function refresh($type=null)
     {
         $this->load->library('migration');
+        
+        //Load the migration config
+        $this->config->load('migration');
 
         if (empty($type))
         {


### PR DESCRIPTION
The following error was received when running a refresh. The third paramemter on CI_DB_forge::create_table() in the migrations expects the Migration config file. Potentially this might be better loaded in the Migration Library? I just copied the config load in the migrate function above.

A PHP Error was encountered
    Severity: 4096
    Message: Argument 3 passed to CI_DB_forge::create_table() must be of the type array, null given, called in /media/server/www/churchbox/manager/website/application/database/migrations/20141007214216_Create_auth_tables.php on line 35 and defined
    Filename: /media/server/www/churchbox/manager/website/system/database/DB_forge.php
    Line Number: 322

```
Backtrace
    - create_table() - Line 35 in /media/server/www/churchbox/manager/website/application/database/migrations/20141007214216_Create_auth_tables.php
```
