### PR TITLE
Update CIDbModel to allow joining other tables.

### DIFF
--- a/myth/Models/CIDbModel.php
+++ b/myth/Models/CIDbModel.php
@@ -358,7 +358,7 @@ class CIDbModel
             // We only need to modify the where statement if
             // temp_with_deleted is false.
             if ($this->temp_with_deleted !== true) {
-                $this->db->where($this->soft_delete_key, false);
+                $this->db->where($this->table_name . "." . $this->soft_delete_key, false);
             }
 
             $this->temp_with_deleted = false;
@@ -398,7 +398,7 @@ class CIDbModel
             // We only need to modify the where statement if
             // temp_with_deleted is false.
             if ($this->temp_with_deleted !== true) {
-                $this->db->where($this->soft_delete_key, false);
+                $this->db->where($this->table_name . "." . $this->soft_delete_key, false);
             }
 
             $this->temp_with_deleted = false;
@@ -469,7 +469,7 @@ class CIDbModel
             // We only need to modify the where statement if
             // temp_with_deleted is false.
             if ($this->temp_with_deleted !== true) {
-                $this->db->where($this->soft_delete_key, false);
+                $this->db->where($this->table_name . "." . $this->soft_delete_key, false);
             }
 
             $this->temp_with_deleted = false;

--- a/tests/unit/myth/Models/CIDbModelTest.php
+++ b/tests/unit/myth/Models/CIDbModelTest.php
@@ -102,7 +102,7 @@ class CIDbModelTest extends \Codeception\TestCase\Test
     {
         $this->model->soft_delete(true);
 
-        $this->model->db->shouldReceive('where')->once()->with('deleted', 0)->andReturn( $this->model->db );
+        $this->model->db->shouldReceive('where')->once()->with('records_table.deleted', 0)->andReturn( $this->model->db );
         $this->model->db->shouldReceive('where')->once()->with('id', 1)->andReturn( $this->model->db );
         $this->model->db->shouldReceive('get')->once()->with('records_table')->andReturn( $this->model->db );
         $this->model->db->shouldReceive('row')->once()->andReturn('fake object');
@@ -146,7 +146,7 @@ class CIDbModelTest extends \Codeception\TestCase\Test
     {
         $this->model->soft_delete(true);
 
-        $this->model->db->shouldReceive('where')->once()->with('deleted', 0)->andReturn( $this->model->db );
+        $this->model->db->shouldReceive('where')->once()->with('records_table.deleted', 0)->andReturn( $this->model->db );
         $this->model->db->shouldReceive('where')->once()->with('name', 'Darth')->andReturn( $this->model->db );
         $this->model->db->shouldReceive('get')->once()->with('records_table')->andReturn( $this->model->db );
         $this->model->db->shouldReceive('row')->once()->andReturn('fake object');
@@ -192,7 +192,7 @@ class CIDbModelTest extends \Codeception\TestCase\Test
 
         $this->model->soft_delete(true);
 
-        $this->model->db->shouldReceive('where')->once()->with('deleted', 0)->andReturn( $this->model->db );
+        $this->model->db->shouldReceive('where')->once()->with('records_table.deleted', 0)->andReturn( $this->model->db );
         $this->model->db->shouldReceive('where_in')->once()->with('id', $ids)->andReturn( $this->model->db );
         $this->model->db->shouldReceive('get')->once()->with('records_table')->andReturn( $this->model->db );
         $this->model->db->shouldReceive('result')->once()->andReturn('fake object');
@@ -240,7 +240,7 @@ class CIDbModelTest extends \Codeception\TestCase\Test
 
         $this->model->soft_delete(true);
 
-        $this->model->db->shouldReceive('where')->once()->with('deleted', 0)->andReturn( $this->model->db );
+        $this->model->db->shouldReceive('where')->once()->with('records_table.deleted', 0)->andReturn( $this->model->db );
         $this->model->db->shouldReceive('where')->once()->with('name', $ids)->andReturn( $this->model->db );
         $this->model->db->shouldReceive('get')->once()->with('records_table')->andReturn( $this->model->db );
         $this->model->db->shouldReceive('result')->once()->andReturn('fake object');
@@ -283,7 +283,7 @@ class CIDbModelTest extends \Codeception\TestCase\Test
     {
         $this->model->soft_delete(true);
 
-        $this->model->db->shouldReceive('where')->once()->with('deleted', 0)->andReturn( $this->model->db );
+        $this->model->db->shouldReceive('where')->once()->with('records_table.deleted', 0)->andReturn( $this->model->db );
         $this->model->db->shouldReceive('get')->once()->with('records_table')->andReturn( $this->model->db);
         $this->model->db->shouldReceive('result')->once()->andReturn('fake object');
 


### PR DESCRIPTION
When joining other tables which also have a delete column, and using find or find_all, an error is thrown as the delete field is ambiguous. I've added the table name in to the where deleted = 0 section.
```
Column 'deleted' is ambiguous
```